### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/notifications/views.py
+++ b/notifications/views.py
@@ -1,6 +1,6 @@
 import json
 import logging
-
+import traceback
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
@@ -269,4 +269,5 @@ def test_token(request):
     except messaging.UnregisteredError:
         return Response({'error': 'Token is not registered'}, status=400)
     except Exception as e:
-        return Response({'error': str(e)}, status=500)
+        logger.error("Test token error: %s", traceback.format_exc())
+        return Response({'error': 'An internal error has occurred.'}, status=500)


### PR DESCRIPTION
Potential fix for [https://github.com/XusanDev07/fcm-notification/security/code-scanning/5](https://github.com/XusanDev07/fcm-notification/security/code-scanning/5)

To fix this issue, we should ensure that error messages returned to external users are generic and do not expose potentially sensitive server-side information. Instead, we should log detailed errors on the server for debugging purposes, and return a standard error message to the user. This fix needs to be applied to the exception block handling generic exceptions in the `test_token` function, specifically lines 271–272. We'll also want to ensure that logging is consistent, so we'll log the exception details (preferably including the stack trace) for diagnosis, but only return a generic error such as "An internal error has occurred." to the client. This will require using the existing `logger` and possibly importing `traceback` if we want to capture the full stack trace.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
