### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/notifications/views.py
+++ b/notifications/views.py
@@ -231,8 +231,8 @@ def get_devices(request):
         
         return Response(data)
     except Exception as e:
-        logger.error(f"Get devices error: {str(e)}")
-        return Response({'error': str(e)}, status=500)
+        logger.error("Get devices error: %s", traceback.format_exc())
+        return Response({'error': 'An internal error has occurred.'}, status=500)
 
 
 @api_view(['POST'])


### PR DESCRIPTION
Potential fix for [https://github.com/XusanDev07/fcm-notification/security/code-scanning/4](https://github.com/XusanDev07/fcm-notification/security/code-scanning/4)

To fix the issue, we should return a generic error message to the API user instead of the raw content of the exception. The underlying exception details (including stack trace) should be logged on the server side for debugging, using the existing logger.  
The fix involves editing the `except Exception as e:` block in the `get_devices` function (lines near 233-235 in notifications/views.py), so that it logs the exception using `logger.error` (optionally using `traceback.format_exc()` for full details), and responds with a generic error message: `'An internal error has occurred.'`.  
No changes outside this block are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
