### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/notifications/views.py
+++ b/notifications/views.py
@@ -52,7 +52,7 @@ def register_device(request):
         
     except Exception as e:
         logger.error(f"Device registration error: {str(e)}")
-        return Response({'error': str(e)}, status=500)
+        return Response({'error': 'An internal error has occurred.'}, status=500)
 
 
 @api_view(['POST'])
@@ -178,7 +178,7 @@ def send_notification(request):
         
     except Exception as e:
         logger.error(f"Send notification error: {str(e)}")
-        return Response({'error': str(e)}, status=500)
+        return Response({'error': 'An internal error has occurred.'}, status=500)
 
 
 @api_view(['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/XusanDev07/fcm-notification/security/code-scanning/1](https://github.com/XusanDev07/fcm-notification/security/code-scanning/1)

To resolve the information exposure issue, replace the line returning the error message directly (`{'error': str(e)}`) with a generic error message that does not reveal internal details. Maintain logging as it is, so detailed errors are still available for developers.  
Specifically:
- Replace `return Response({'error': str(e)}, status=500)` in both exception handlers (`register_device` and `send_notification`, and anywhere similar appears in the shown code) with `return Response({'error': 'An internal error has occurred.'}, status=500)`.
- No new imports or functionality beyond this change are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
