### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/notifications/views.py
+++ b/notifications/views.py
@@ -206,8 +206,8 @@ def get_notifications(request):
         
         return Response(data)
     except Exception as e:
-        logger.error(f"Get notifications error: {str(e)}")
-        return Response({'error': str(e)}, status=500)
+        logger.error("Get notifications error: %s", traceback.format_exc())
+        return Response({'error': 'An internal error has occurred.'}, status=500)
 
 
 @api_view(['GET'])


### PR DESCRIPTION
Potential fix for [https://github.com/XusanDev07/fcm-notification/security/code-scanning/2](https://github.com/XusanDev07/fcm-notification/security/code-scanning/2)

To fix this issue, the error response returned to the user in the `except` block of the `get_notifications` function should be changed from including `str(e)` (the exception message, which may leak sensitive details) to a generic error message such as "An internal error has occurred." At the same time, the exception details should still be logged on the server for debugging purposes. This aligns with best practices in the rest of the file, as seen in other exception handlers.  
**Change**:  
- Edit lines 209–210 in `notifications/views.py` where the exception is logged and the response is returned.
- Log the full stack trace of the exception using `traceback.format_exc()` via `logger.error`, then respond with a generic error message.
- No new imports are necessary; both `traceback` and `logger` are already in use and available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
